### PR TITLE
Add GitHub Actions and tests

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,32 @@
+name: .NET
+
+on:
+  push:
+    paths:
+      - '**/*.cs'
+      - '**/*.csproj'
+      - '**/*.sln'
+      - '.github/workflows/dotnet.yml'
+  pull_request:
+    paths:
+      - '**/*.cs'
+      - '**/*.csproj'
+      - '**/*.sln'
+      - '.github/workflows/dotnet.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      - name: Restore dependencies
+        run: dotnet restore OfflineLabyrinth.sln
+      - name: Build
+        run: dotnet build OfflineLabyrinth.sln --no-restore --configuration Release
+      - name: Test
+        run: dotnet test OfflineLabyrinth.sln --no-build --configuration Release
+

--- a/OfflineLabyrinth.Tests/OfflineLabyrinth.Tests.csproj
+++ b/OfflineLabyrinth.Tests/OfflineLabyrinth.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../OfflineLabyrinth/OfflineLabyrinth.csproj" />
+  </ItemGroup>
+</Project>

--- a/OfflineLabyrinth.Tests/OfflineLabyrinthTests.cs
+++ b/OfflineLabyrinth.Tests/OfflineLabyrinthTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+public class OfflineLabyrinthTests
+{
+    [Fact]
+    public async Task PrintCommandProducesOutput()
+    {
+        using var lab = new OfflineLabyrinth.OfflineLabyrinth(0);
+        using var writer = new StreamWriter(lab.Stream) { NewLine = "\r\n", AutoFlush = true };
+        using var reader = new StreamReader(lab.Stream);
+
+        // read the welcome text
+        for (int i = 0; i < 20; i++)
+        {
+            var line = await reader.ReadLineAsync();
+            if (line == null || line.StartsWith("9 ")) break;
+        }
+
+        await writer.WriteLineAsync("WIDTH 32");
+        var response = await reader.ReadLineAsync();
+        Assert.StartsWith("2", response);
+
+        await writer.WriteLineAsync("HEIGHT 32");
+        response = await reader.ReadLineAsync();
+        Assert.StartsWith("2", response);
+
+        await writer.WriteLineAsync("DEPTH 1");
+        response = await reader.ReadLineAsync();
+        Assert.StartsWith("2", response);
+
+        await writer.WriteLineAsync("START");
+        // read progress until READY
+        string? lineReady;
+        do
+        {
+            lineReady = await reader.ReadLineAsync();
+        } while (lineReady != null && !lineReady.StartsWith("2 READY."));
+
+        Assert.Equal("2 READY.", lineReady);
+
+        await writer.WriteLineAsync("PRINT");
+        var printLine = await reader.ReadLineAsync();
+        Assert.True(printLine!.StartsWith("3 ")); // position line
+    }
+
+    [Fact]
+    public async Task LagIsEnforced()
+    {
+        const int lag = 50;
+        using var lab = new OfflineLabyrinth.OfflineLabyrinth(lag);
+        using var writer = new StreamWriter(lab.Stream) { NewLine = "\r\n", AutoFlush = true };
+        using var reader = new StreamReader(lab.Stream);
+
+        // skip intro
+        for (int i = 0; i < 20; i++)
+        {
+            var line = await reader.ReadLineAsync();
+            if (line == null || line.StartsWith("9 ")) break;
+        }
+
+        var sw = Stopwatch.StartNew();
+        await writer.WriteLineAsync("WIDTH 32");
+        await reader.ReadLineAsync();
+        sw.Stop();
+
+        Assert.True(sw.ElapsedMilliseconds >= lag, $"Expected at least {lag}ms lag but got {sw.ElapsedMilliseconds}ms");
+    }
+}

--- a/OfflineLabyrinth.sln
+++ b/OfflineLabyrinth.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfflineLabyrinth", "OfflineLabyrinth\OfflineLabyrinth.csproj", "{1C363549-EFEB-47B4-B1CE-7DA2530DFD6F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OfflineLabyrinth.Tests", "OfflineLabyrinth.Tests\OfflineLabyrinth.Tests.csproj", "{8267CB49-3580-4BEC-BB70-8B8D6DF1481E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -17,6 +19,10 @@ Global
 		{1C363549-EFEB-47B4-B1CE-7DA2530DFD6F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1C363549-EFEB-47B4-B1CE-7DA2530DFD6F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1C363549-EFEB-47B4-B1CE-7DA2530DFD6F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{1C363549-EFEB-47B4-B1CE-7DA2530DFD6F}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+               {1C363549-EFEB-47B4-B1CE-7DA2530DFD6F}.Release|Any CPU.Build.0 = Release|Any CPU
+               {8267CB49-3580-4BEC-BB70-8B8D6DF1481E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+               {8267CB49-3580-4BEC-BB70-8B8D6DF1481E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+               {8267CB49-3580-4BEC-BB70-8B8D6DF1481E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+               {8267CB49-3580-4BEC-BB70-8B8D6DF1481E}.Release|Any CPU.Build.0 = Release|Any CPU
+       EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- add xUnit test project for `OfflineLabyrinth`
- verify `PRINT` command works and lag enforcement
- add GitHub Actions workflow to run the tests

## Testing
- `dotnet restore OfflineLabyrinth.sln` *(fails: Unable to load the service index)*
- `dotnet test OfflineLabyrinth.sln --no-build` *(fails: restore step failed)*