### PR TITLE
Fix SimpleChannel conflicts and target .NET 8

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -24,9 +24,9 @@ jobs:
         with:
           dotnet-version: 8.0.x
       - name: Restore dependencies
-        run: dotnet restore OfflineLabyrinth.sln
+        run: dotnet restore OfflineLabyrinth/OfflineLabyrinth.sln
       - name: Build
-        run: dotnet build OfflineLabyrinth.sln --no-restore --configuration Release
+        run: dotnet build OfflineLabyrinth/OfflineLabyrinth.sln --no-restore --configuration Release
       - name: Test
-        run: dotnet test OfflineLabyrinth.sln --no-build --configuration Release
+        run: dotnet test OfflineLabyrinth/OfflineLabyrinth.sln --no-build --configuration Release
 

--- a/OfflineLabyrinth/OfflineLabyrinth.Tests/OfflineLabyrinth.Tests.csproj
+++ b/OfflineLabyrinth/OfflineLabyrinth.Tests/OfflineLabyrinth.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/OfflineLabyrinth/OfflineLabyrinth/OfflineLabyrinth.cs
+++ b/OfflineLabyrinth/OfflineLabyrinth/OfflineLabyrinth.cs
@@ -22,11 +22,11 @@ public class OfflineLabyrinth : IDisposable
         var serverOutQueue = new SimpleChannel<byte[]>();
 
         // start lag processing tasks
-        _ = ProcessOutgoing(clientOutQueue.Reader, serverIn.Writer, lagMilliseconds, _cts.Token);
-        _ = ProcessOutgoing(serverOutQueue.Reader, clientIn.Writer, lagMilliseconds, _cts.Token);
+        _ = ProcessOutgoing(clientOutQueue.ReaderEnd, serverIn.WriterEnd, lagMilliseconds, _cts.Token);
+        _ = ProcessOutgoing(serverOutQueue.ReaderEnd, clientIn.WriterEnd, lagMilliseconds, _cts.Token);
 
-        _clientStream = new LagStream(clientIn.Reader, clientOutQueue.Writer, _cts.Token);
-        var serverStream = new LagStream(serverIn.Reader, serverOutQueue.Writer, _cts.Token);
+        _clientStream = new LagStream(clientIn.ReaderEnd, clientOutQueue.WriterEnd, _cts.Token);
+        var serverStream = new LagStream(serverIn.ReaderEnd, serverOutQueue.WriterEnd, _cts.Token);
 
         // run server session
         _serverTask = Task.Run(() => Session.Run(serverStream, _cts.Token));
@@ -122,13 +122,16 @@ internal class SimpleChannel<T>
     private readonly SemaphoreSlim _signal = new(0);
     private bool _completed;
 
-    public Reader Reader { get; }
-    public Writer Writer { get; }
+    private readonly Reader _readerEnd;
+    private readonly Writer _writerEnd;
+
+    public Reader ReaderEnd { get { return _readerEnd; } }
+    public Writer WriterEnd { get { return _writerEnd; } }
 
     public SimpleChannel()
     {
-        Reader = new Reader(this);
-        Writer = new Writer(this);
+        _readerEnd = new Reader(this);
+        _writerEnd = new Writer(this);
     }
 
     public class Reader

--- a/OfflineLabyrinth/OfflineLabyrinth/OfflineLabyrinth.csproj
+++ b/OfflineLabyrinth/OfflineLabyrinth/OfflineLabyrinth.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
- rename channel endpoint properties to avoid class name clashes
- target .NET 8 for OfflineLabyrinth and tests

## Testing
- `dotnet test OfflineLabyrinth/OfflineLabyrinth.sln --configuration Release` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json)*