### PR TITLE
Fix BFS neighbor check

### DIFF
--- a/OfflineLabyrinth/OfflineLabyrinth/Labyrinth.cs
+++ b/OfflineLabyrinth/OfflineLabyrinth/Labyrinth.cs
@@ -259,7 +259,7 @@ namespace OfflineLabyrinth
                     nodes.Enqueue(new Node(current.W + 1, current.H, current.D, current));
                 }
 
-                if (current.H > 0 && ((data[current.D, current.H - 1, current.W] & 0b101) == 0 || (data[current.D, current.H - 1, current.W] & 0b010) == 0b110))
+                if (current.H > 0 && ((data[current.D, current.H - 1, current.W] & 0b101) == 0 || (data[current.D, current.H - 1, current.W] & 0b110) == 0b010))
                 {
                     data[current.D, current.H - 1, current.W] |= 0b100;
                     nodes.Enqueue(new Node(current.W, current.H - 1, current.D, current));


### PR DESCRIPTION
## Summary
- fix conditional check for upper neighbor when calculating distances

## Testing
- `dotnet build OfflineLabyrinth/OfflineLabyrinth/OfflineLabyrinth.csproj -c Release`
- `timeout 10s dotnet run --project testapp/testapp.csproj && echo SUCCESS || echo TIMEOUT` *(fails: exit code due to build errors)*
