### PR TITLE
Show detailed test output on GitHub

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -28,5 +28,5 @@ jobs:
       - name: Build
         run: dotnet build OfflineLabyrinth/OfflineLabyrinth.sln --no-restore --configuration Release
       - name: Test
-        run: timeout 30s dotnet test OfflineLabyrinth/OfflineLabyrinth.sln --no-build --configuration Release
+        run: timeout 30s dotnet test OfflineLabyrinth/OfflineLabyrinth.sln --no-build --configuration Release --logger "console;verbosity=detailed"
 


### PR DESCRIPTION
## Summary
- print test names and timings during CI runs by enabling detailed console logger

## Testing
- `dotnet test OfflineLabyrinth/OfflineLabyrinth.sln --logger "console;verbosity=detailed"`


------
https://chatgpt.com/codex/tasks/task_e_6898ce7925208320b828f9bcdaf84b8b